### PR TITLE
Check the type argument for brewer.pal

### DIFF
--- a/R/pal-brewer.r
+++ b/R/pal-brewer.r
@@ -33,6 +33,7 @@ pal_name <- function(palette, type) {
   switch(type, 
     div = RColorBrewer:::divlist, 
     qual = RColorBrewer:::quallist, 
-    seq = RColorBrewer:::seqlist
+    seq = RColorBrewer:::seqlist,
+    stop("Unknown palette type. 'type' should be one of ", paste(dQuote(unique(RColorBrewer:::catlist)), collapse=", "))
   )[palette]  
 }


### PR DESCRIPTION
Previously, specifying a non valid argument resulted in a cryptic error
because pal_name returned NULL.
