### PR TITLE
Add a warning when the shape palette is exceeded

### DIFF
--- a/R/pal-shape.r
+++ b/R/pal-shape.r
@@ -4,6 +4,9 @@
 #' @export
 shape_pal <- function(solid = TRUE) {
   function(n) {
+    if (n > 6) {
+      warning("The shape palette can deal with a maximum of 6 discrete values because \n  more than 6 becomes difficult to discriminate; but you have ", n, ".\n  Consider specifying shapes manually if you absolutely want them.")
+    }
     if (solid) {
       c(16, 17, 15, 3, 7, 8)[seq_len(n)]
     } else {


### PR DESCRIPTION
This warning was present in ggplot before and is necessary to understand why
shapes beyond the 6th are suppresses. But this being outside of the scope of
ggplot, I did not know how to phrase the warning exactly.

For information, the warning in ggplot was:

```
scale_shape_discrete can deal with
a maximum of 6 discrete values, but you have 11.  See ?scale_manual for a
possible alternative
```
