### PR TITLE
fix date-time conversion.

### DIFF
--- a/R/date-time.r
+++ b/R/date-time.r
@@ -15,10 +15,11 @@ floor_date <- function(date, time) {
 }
 floor_time <- function(date, time) {
   prec <- parse_unit_spec(time)
+  t = time_trans()
   if (prec$unit == "sec") {
-    to_time(round_any(as.numeric(date), prec$mult))
+    t$inv(round_any(t$trans(date), prec$mult))
   } else if (prec$unit == "min") {
-    to_time(round_any(as.numeric(date), prec$mult * 60))    
+    t$inv(round_any(t$trans(date), prec$mult * 60))    
   } else {
     as.POSIXct(
       cut(date, time, right = TRUE, include.lowest = TRUE), 


### PR DESCRIPTION
Came across an issue where:

```
> cat pitches.tsv
    2012-08-08 20:25:39 B   90.8
    2012-08-08 20:25:53 S   92.6
    2012-08-08 20:26:15 B   93.2
    2012-08-08 20:26:33 X   94.0
    2012-08-08 20:27:38 B   93.5
    2012-08-08 20:28:07 X   93.9
    2012-08-08 20:29:23 S   94.1
    2012-08-08 20:29:42 X   93.7
    2012-08-08 20:30:40 X   94.8
    2012-08-08 20:31:28 X   93.3
> cat pitches.tsv | Rscript -e "
        library(ggplot2); \
        library(scales); \
        d <- read.csv('stdin', header=F, sep='\\\\t', col.names=c('time', 'type', 'pitch_speed')); \
        png('gio-pitch-speed.png'); \
        ggplot(d, aes(x=as.POSIXlt(time), y=pitch_speed, colour=type, shape=type)) \
          + geom_point() \
          + labs(title='Pitch Speed Over Time for Gio Gonzalez', x='Time', y='Pitch Speed') \
          + scale_x_datetime(breaks=date_breaks('1 hour'), minor_breaks=date_breaks('15 min'), labels=date_format('%H:%M')) \
          + scale_colour_discrete(name = 'Pitch Type') \
          + scale_shape_discrete(name = 'Pitch Type'); \
        dev.off()"
```

Resulted in:

```
Error in floor_time(range[1], size) : could not find function "to_time"
Calls: print ... <Anonymous> -> fullseq -> fullseq.POSIXt -> seq -> floor_time 
```

Poking around the `scales` repo, I saw that it appears `to_time` has been deprecated and extracted out in `time_trans`. Updated the `floor_time` function to use `time_trans`.
