### PR TITLE
Including the option to set a different decimal mark. 

### DIFF
--- a/R/formatter.r
+++ b/R/formatter.r
@@ -58,8 +58,10 @@ comma <- function(x, ...) {
 #' finance <- dollar_format(negative_parens = TRUE)
 #' finance(c(-100, 100))
 dollar_format <- function(prefix = "$", suffix = "",
-                          largest_with_cents = 100000, ..., big.mark = ",",
+                          largest_with_cents = 100000, ..., big.mark = ",", decimal.mark = ".",
                           negative_parens = FALSE) {
+  options(warn = 1)
+
   function(x) {
     if (length(x) == 0) return(character())
     x <- round_any(x, 0.01)
@@ -75,8 +77,21 @@ dollar_format <- function(prefix = "$", suffix = "",
       x <- abs(x)
     }
 
-    amount <- format(abs(x), nsmall = nsmall, trim = TRUE, big.mark = big.mark,
-      scientific = FALSE, digits = 1L)
+    if (big.mark == decimal.mark) {
+
+      amount <- format(abs(x), nsmall = nsmall, trim = TRUE, decimal.mark = '.',
+                       scientific = FALSE, digits = 1L)
+      warning(paste0("'big.mark' and 'decimal.mark' are equal ",
+                     paste0("'",big.mark, "'"),
+                     " which could be confusing.",
+                     " Try to set decimal.mark.",sep=' '))
+
+    } else {
+
+      amount <- format(abs(x), nsmall = nsmall, trim = TRUE, big.mark = big.mark,
+                       scientific = FALSE, digits = 1L, decimal.mark = decimal.mark)
+    }
+
 
     if (negative_parens) {
       paste0(ifelse(negative, "(", ""), prefix, amount, suffix, ifelse(negative, ")", ""))


### PR DESCRIPTION
Can be useful in countries where "," is used instead of ".", like Brazil. I have been using this new feature to write apps with brazilian reals, where we use "," as the decimal character.

Every time that the user try to set just big.mark to "." it raises a warning advising the user to set a different decimal mark.