### PR TITLE
added label size control to show_col()

### DIFF
--- a/R/colour-manip.r
+++ b/R/colour-manip.r
@@ -81,7 +81,7 @@ alpha <- function(colour, alpha = NA) {
 #' @param borders colour of the borders of the tiles; matches the \code{border} argument of \code{\link[graphics]{rect}}. The default means \code{par("fg")}. Use \code{border = NA} to omit borders.
 #' @export
 #' @importFrom graphics par plot rect text
-show_col <- function(colours, labels = TRUE, borders = NULL, text_size) {
+show_col <- function(colours, labels = TRUE, borders = NULL, cex_text) {
   n <- length(colours)
   ncol <- ceiling(sqrt(n))
   nrow <- ceiling(n / ncol)
@@ -97,6 +97,6 @@ show_col <- function(colours, labels = TRUE, borders = NULL, text_size) {
   rect(col(colours) - 1, -row(colours) + 1, col(colours), -row(colours),
     col = colours, border = borders)
   if ( labels ) {
-    text(col(colours) - 0.5, -row(colours) + 0.5, colours, cex= text_size)
+    text(col(colours) - 0.5, -row(colours) + 0.5, colours, cex= cex_text)
   }
 }

--- a/R/colour-manip.r
+++ b/R/colour-manip.r
@@ -81,7 +81,7 @@ alpha <- function(colour, alpha = NA) {
 #' @param borders colour of the borders of the tiles; matches the \code{border} argument of \code{\link[graphics]{rect}}. The default means \code{par("fg")}. Use \code{border = NA} to omit borders.
 #' @export
 #' @importFrom graphics par plot rect text
-show_col <- function(colours, labels = TRUE, borders = NULL) {
+show_col <- function(colours, labels = TRUE, borders = NULL, text_size) {
   n <- length(colours)
   ncol <- ceiling(sqrt(n))
   nrow <- ceiling(n / ncol)
@@ -97,6 +97,6 @@ show_col <- function(colours, labels = TRUE, borders = NULL) {
   rect(col(colours) - 1, -row(colours) + 1, col(colours), -row(colours),
     col = colours, border = borders)
   if ( labels ) {
-    text(col(colours) - 0.5, -row(colours) + 0.5, colours)
+    text(col(colours) - 0.5, -row(colours) + 0.5, colours, cex= text_size)
   }
 }

--- a/man/show_col.Rd
+++ b/man/show_col.Rd
@@ -4,7 +4,7 @@
 \alias{show_col}
 \title{Show colours.}
 \usage{
-show_col(colours, labels = TRUE, borders = NULL)
+show_col(colours, labels = TRUE, borders = NULL, text_size)
 }
 \arguments{
 \item{colours}{a character vector of colours}
@@ -12,6 +12,9 @@ show_col(colours, labels = TRUE, borders = NULL)
 \item{labels}{boolean, whether to show the hexadecimal representation of the colours in each tile}
 
 \item{borders}{colour of the borders of the tiles; matches the \code{border} argument of \code{\link[graphics]{rect}}. The default means \code{par("fg")}. Use \code{border = NA} to omit borders.}
+  
+ \item{cex_text}{size of labels, works same as \code{cex} parameter of \code{plot()}}
+
 }
 \description{
 A quick and dirty way to show colours in a plot.


### PR DESCRIPTION
problem: trying to plot great enough matrices ( 400X400 on...) produces unreadable labels
proposed solution: giving the user control over label size.

notes:
- parameter named cex_text consistently with plot() function
- updated show_col() function and related documentation